### PR TITLE
tidy(docs): :memo: adds an example of cyclic validation errors

### DIFF
--- a/lib/dagex.ex
+++ b/lib/dagex.ex
@@ -105,6 +105,9 @@ defmodule Dagex do
       iex> {:ok, bulldog} = %AnimalType{name: "Bulldog"} |> Repo.insert()
       iex> {:edge_created, _edge} = AnimalType.create_edge(dog, bulldog) |> Repo.dagex_update()
       iex>
+      iex> # returns an error if an edge insertion would create a cycle
+      iex> {:error, :cyclic_edge} = AnimalType.create_edge(bulldog, pet) |> Repo.dagex_update()
+      iex>
       iex> # we can get the direct children of a node:
       iex> children = AnimalType.children(animal) |> Repo.all()
       iex> assert_lists_equal(children, [pet, livestock])


### PR DESCRIPTION
This makes it more obvious in the docs that DAG validation is present (and how it works).

(Otherwise you have to read the tests to see if/how this works)